### PR TITLE
[FR] option to group/override segment2 to consolidate reported routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This plugin helps connect your Craft app with New Relic APM by setting transacti
 
 2. In the Control Panel, go to Settings → Plugins and click the “Install” button for _New Relic_.
 
-3. There is no Step 3.
+3. You can edit settings for the plugin as needed.
 
 _The New Relic plugin is also available for installation via the Craft CMS Plugin Store._
 

--- a/src/NewRelic.php
+++ b/src/NewRelic.php
@@ -80,7 +80,14 @@ class NewRelic extends Plugin
 
 				if ($request->getSegment(2))
 				{
-					$name .= "/" . $request->getSegment(2);
+					if ($this->getSettings()->includeSegment2 === '1')
+					{
+						$name .= "/" . $request->getSegment(2);
+					}
+					else
+					{
+						$name .= "/*";
+					}
 				}
 
 				if ($request->getIsLivePreview())

--- a/src/NewRelic.php
+++ b/src/NewRelic.php
@@ -78,16 +78,16 @@ class NewRelic extends Plugin
 
 				$name = $request->getSegment(1);
 
-				if ($request->getSegment(2))
+				$segment2Name = $request->getSegment(2);
+				if ($segment2Name)
 				{
-					if ($this->getSettings()->includeSegment2 === '1')
+					$segment2FixedName = $this->getSettings()->groupSegment2As;
+					if ($segment2FixedName !== '')
 					{
-						$name .= "/" . $request->getSegment(2);
+						$segment2Name = $segment2FixedName;
 					}
-					else
-					{
-						$name .= "/*";
-					}
+
+					$name .= "/" . $segment2Name;
 				}
 
 				if ($request->getIsLivePreview())

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -32,6 +32,12 @@ class Settings extends Model
      */
     public $appName = '';
 
+    /**
+     * Some field model attribute
+     *
+     * @var boolean
+     */
+    public $includeSegment2 = '1';
 
     /*
      * Public Methods
@@ -50,6 +56,8 @@ class Settings extends Model
         return [
             ['appName', 'string'],
             ['appName', 'default', 'value' => ''],
+            ['includeSegment2', 'string'],
+            ['includeSegment2', 'default', 'value' => '1'],
         ];
     }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -37,7 +37,7 @@ class Settings extends Model
      *
      * @var boolean
      */
-    public $includeSegment2 = '1';
+    public $groupSegment2As = '';
 
     /*
      * Public Methods
@@ -56,8 +56,8 @@ class Settings extends Model
         return [
             ['appName', 'string'],
             ['appName', 'default', 'value' => ''],
-            ['includeSegment2', 'string'],
-            ['includeSegment2', 'default', 'value' => '1'],
+            ['groupSegment2As', 'string'],
+            ['groupSegment2As', 'default', 'value' => ''],
         ];
     }
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -9,3 +9,11 @@
     name: 'appName',
     value: settings['appName']})
 }}
+
+{{ forms.textField({
+    label: 'Include Segment 2',
+    instructions: '(If you want all second segments to be replaced with a "*", set this to a value other than "1".)',
+    id: 'includeSegment2',
+    name: 'includeSegment2',
+    value: settings['includeSegment2']})
+}}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -11,9 +11,9 @@
 }}
 
 {{ forms.textField({
-    label: 'Include Segment 2',
-    instructions: '(If you want all second segments to be replaced with a "*", set this to a value other than "1".)',
-    id: 'includeSegment2',
-    name: 'includeSegment2',
-    value: settings['includeSegment2']})
+    label: 'Group Segment 2 As',
+    instructions: '(If you want all second segments to be replaced with "*" or any other character or string, set this field. Leave it empty otherwise.)',
+    id: 'groupSegment2As',
+    name: 'groupSegment2As',
+    value: settings['groupSegment2As']})
 }}


### PR DESCRIPTION
Hello @michaelrog,

Thanks a lot for this plugin.

Our site makes use of slugs in segment2 meaning a lot of NewRelic paths are created though they should be grouped together. This PR suggests having a setting that helps us and any other site that uses a `slug` in Segment2 group such paths.

I had deployed this as a fork 9 months ago due to urgency at that time, This PR is to suggest it as a feature of your Plugin instead.

Looking forward to your response.

Thanks!